### PR TITLE
Remove unneeded join

### DIFF
--- a/src/main/kotlin/db.kt
+++ b/src/main/kotlin/db.kt
@@ -313,7 +313,6 @@ class Database(private val config: Config) {
             SELECT shortcode, users.username, thumbnailURL, imageURL, caption, timestamp, ord
             FROM igposts
             LEFT JOIN users on users.id=igposts.userID
-            LEFT JOIN profile_users on profile_users.userid=users.id
             WHERE users.username=?
             ORDER BY timestamp DESC
             LIMIT ?


### PR DESCRIPTION
Fixes #96

## Proposed Changes

  - Remove unneeded join on `profiles` table that was causing users who appear in multiple profiles to have images duplicated for each profile they were part of.